### PR TITLE
Add --path synonym for --digipeaters. Add docs.

### DIFF
--- a/afsk/ax25.py
+++ b/afsk/ax25.py
@@ -225,8 +225,9 @@ def main(arguments=None):
 	parser.add_argument(
 		'-d',
 		'--digipeaters',
+		'--path',
 		default=b'WIDE1-1,WIDE2-1',
-		help='Comma separated list of digipeaters to address.'
+		help='Digipeater path to use. "New Paradigm" recommendations are "WIDE1-1,WIDE2-1" for mobile and "WIDE2-1" for fixed stations. Defaults to "WIDE1-1,WIDE2-1."'
 	)
 	parser.add_argument(
 		'-o',


### PR DESCRIPTION
Update documentation for the --digitpeaters CLI flag to clarify that
this is how to set the APRS "path," and that it defaults to a
mobile-appropriate WIDE1-1,WIDE2-1.

Add a --path synonym for this --digipeaters flag.

See

- http://wa8lmf.net/DigiPaths/NNNN-Digi-Demo.htm
- http://info.aprs.net/index.php?title=Paths

Resolves #5 
