### PR TITLE
Bump pyaudio to 0.2.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 argparse==1.1
 bitarray==0.8.1
-PyAudio==0.2.7
+PyAudio==0.2.11
 audiogen==0.0.2


### PR DESCRIPTION
PyAudio 0.2.7 is no longer on PyPi, bumping this to 0.2.11.